### PR TITLE
Replace PostgreSQL function used to pad timestamp

### DIFF
--- a/shmig
+++ b/shmig
@@ -267,7 +267,7 @@ postgresql_check(){
 }
 
 postgresql_previous_versions(){
-   local fields="lpad(version, 10, '0') as version"
+   local fields="to_char(version,'0000000000') as version"
    __generic_previous_versions '"' "$1" "$fields"
 }
 


### PR DESCRIPTION
I was experiencing the following error with PostgreSQL 9.4.1:
```
ERROR:  function lpad(integer, integer, unknown) does not exist at character 8
```
The `lpad` function is `lpad(string text, length int [, fill text])` and the `version` field is of type `integer`.

This seems to fix the error for me. I tested with two migration files, `999999999-test1.sql` and `1000000000-test2.sql` which seems to work as intended.