### PR TITLE
Establish mariadb compatibility

### DIFF
--- a/shmig
+++ b/shmig
@@ -228,7 +228,7 @@ mysql_cli(){
 
 mysql_check(){
   __generic_checker "$MYSQL" "show tables;" \
-    "create table \`$SCHEMA_TABLE\`(version int not null primary key, migrated_at timestamp not null default utc_timestamp());"
+    "create table \`$SCHEMA_TABLE\`(version int not null primary key, migrated_at timestamp not null default current_timestamp;"
 }
 
 mysql_previous_versions(){


### PR DESCRIPTION
`TIMESTAMP DEFAULT UTC_TIMESTAMP()` (line 231) breaks compatibility with Maria DB.

See also http://dba.stackexchange.com/questions/20217/mysql-set-utc-time-as-default-timestamp