### PR TITLE
Add '-follow' for find to work with symlinks as well

### DIFF
--- a/shmig
+++ b/shmig
@@ -381,7 +381,7 @@ EOF
 
 # a wrapper for find that looks for migration files
 find_migrations(){
-  find "$MIGRATIONS" -maxdepth 1 -mindepth 1 -type f "$@"
+  find "$MIGRATIONS" -maxdepth 1 -mindepth 1 -type f -follow "$@"
 }
 
 # extract version from migration file name


### PR DESCRIPTION
Symlinks are not appearing in migrations `pending` list.

I have a some migrations in the `$MIGRATIONS` path which are actually symlinks to regular files in another location. This small PR enables `find` to _follow_ those symlinks (assuming they are regular files as well).